### PR TITLE
manage `checked` and `value` properties of INPUT elements

### DIFF
--- a/src/view.js
+++ b/src/view.js
@@ -940,7 +940,9 @@
 
 			// add new or mutate existing not matching old
 			// also handles diffing of wrapped event handlers via exposed original (_fn)
-			if (!(name in op) || np[name] !== op[name])
+			if (isInputProp(targ.tagName, name))
+				targ[name] = np[name];
+			else if (!(name in op) || np[name] !== op[name])
 				set(targ, name, np[name], ns, init);
 		}
 		// remove any removed
@@ -949,6 +951,19 @@
 
 			if (!(name in np))
 				del(targ, name, ns, init);
+		}
+	}
+
+	function isInputProp(tag, name) {
+		switch (tag) {
+			case 'INPUT':
+				return name === 'value' || name === 'checked';
+			case 'TEXTAREA':
+				return name === 'value';
+			case 'SELECT':
+				return name === 'value' || name === 'selectedIndex';
+			case 'OPTION':
+				return name === 'selected';
 		}
 	}
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -741,6 +741,21 @@ QUnit.module("Attrs/Props");
 		var expcHtml = '<input type="checkbox" id="check2">';
 		evalOut(assert, checkEl, domvm.html(check2.vm.node), expcHtml, callCounts, { removeAttribute: 1 });
 	});
+
+	QUnit.test("Input Attribute", function(assert) {
+		var model = new Check('check3', true);
+		var view  = domvm.view(CheckView, model).mount(testyDiv);
+		var el    = view.node.el;
+
+		// user interaction
+		el.checked = false;
+
+		// redraw with model.checked still true
+		view.redraw();
+
+		// the visual state should be equal to the model state
+		assert.equal(el.checked, model.checked);
+	});
 })();
 
 // TODO: assert triple equal outerHTML === domvm.html(vm.node) === hardcoded html


### PR DESCRIPTION
### Motivation
The first time a `input` element is rendered with a initial value for `checked` attributes it sets `checked` property with that value, if the `checked` attribute is changed dinamically the property does no change, so it would looks like doesn't works, because `chacked` attribute belongs to `defaultChecked` property, hence you can not trust `vm.node.el.checked`. The same issue with `value`.

This PR solves that problem. So now you can savely do:
```
['input', {type; 'checkbox', checked: isChecked}]
```