### PR TITLE
fixing the browser back button when using history API

### DIFF
--- a/src/route.js
+++ b/src/route.js
@@ -125,7 +125,7 @@
 			if (!useHist && e.type == "popstate")
 				return;
 
-			if (gotoLocChg) {
+			if (!useHist && gotoLocChg) {
 				gotoLocChg = false;
 				return;
 			}


### PR DESCRIPTION
I noticed that the domvm router would only `.goto()` a route every second use of the browser's back button when `useHist: true`. This behavior occured on the threaditjs example as well as my own code.

With this change, the back button appears to work as expected.