### PR TITLE
making initFetch behave in a more intuitive way?

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -30,7 +30,7 @@
 			}
 
 			var okFn = cb,
-				errFn = noop;
+				errFn = function (err) { return Promise.reject(err); }; 
 
 			if (cb instanceof Array) {
 				okFn = cb[0];
@@ -78,7 +78,7 @@
 					function(err) {
 						event.error = err;
 						api.fire(event);
-						return err;
+						return Promise.reject(err);
 					}
 				);
 


### PR DESCRIPTION
Got confused using `w.get()`. Thought the Promise would be rejected when there was an error. It was fulfilled, though.

This might or might not be a good change - while it closes one trap (`w.get()` looking kind of like it returns a Promise that works similar to `fetch()` but having quite different semantics in the error case), it might open another (tempting people to chain handlers with `.then()` that should rather be passed as callback parameters to `w.get()` in order to run before `api.fire()`).